### PR TITLE
Return empty keywords when article text is None

### DIFF
--- a/newsfetch/newspaper_handler.py
+++ b/newsfetch/newspaper_handler.py
@@ -55,7 +55,8 @@ class ArticleHandler:
         keywords = self.__process_keywords(self.__article.keywords)
 
         if not keywords:
-            return extract_keywords(self.article)
+            article = self.article
+            return extract_keywords(article) if article else []
 
         return keywords
 


### PR DESCRIPTION
`ArticleHandler.keywords` falls back to `extract_keywords(self.article)` when newspaper4k returns no keywords, but `self.article` is `None` for pages with no extractable body text, so `extract_keywords` crashes on `article.lower()`. This guards the fallback and returns `[]` when there's no article text, matching the property's other empty-result paths.

The repo has no test suite to add a case to, so this is verified with a direct repro of the `None` input against the fallback.

Closes #109
